### PR TITLE
Use github.com/parkr/changelog for the parsing & formatting of the issue

### DIFF
--- a/api.go
+++ b/api.go
@@ -62,13 +62,13 @@ func (h APIHandler) CreateRadarItem(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h APIHandler) ListRadarItems(w http.ResponseWriter, r *http.Request) {
-	radarItems, err := h.RadarItems.List(r.Context())
+	oldRadarItems, newRadarItems, err := h.RadarItems.List(r.Context())
 	if err != nil {
 		h.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	err = json.NewEncoder(w).Encode(radarItems)
+	err = json.NewEncoder(w).Encode(map[string]interface{}{"OldItems": oldRadarItems, "NewRadarItems": newRadarItems})
 	if err != nil {
 		h.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/github_test.go
+++ b/github_test.go
@@ -2,37 +2,38 @@ package radar
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJoinLinksIntoBody(t *testing.T) {
-	header := "A new day! Here's what you have saved:"
+	header := "A new day, @parkr! Here's what you have saved:"
 	oldLinks := []RadarItem{{URL: "https://github.com"}, {URL: "https://ben.balter.com", Title: "Ben Balter"}}
 	newLinks := []RadarItem{{URL: "https://byparker.com"}, {URL: "https://jvns.ca"}}
 	expected := header + `
 
-[*Previously:*](https://github.com/parkr/radar/issues/1)
+## [*Previously:*](https://github.com/parkr/radar/issues/1)
 
-- [ ] [GitHub: Where the world builds software · GitHub](https://github.com)
-- [ ] [Ben Balter](https://ben.balter.com)
+  * [ ] [GitHub: Where the world builds software · GitHub](https://github.com)
+  * [ ] [Ben Balter](https://ben.balter.com)
 
-New:
+## New:
 
-- [ ] [Parker Moore | By Parker](https://byparker.com)
-- [ ] [Julia Evans](https://jvns.ca)
-
-/cc @parkr
+  * [ ] [Parker Moore | By Parker](https://byparker.com)
+  * [ ] [Julia Evans](https://jvns.ca)
 `
 
 	body, err := generateBody(&tmplData{
 		OldIssueURL: "https://github.com/parkr/radar/issues/1",
-		OldIssues:   oldLinks,
-		NewIssues:   newLinks,
+		OldLinks:    oldLinks,
+		NewLinks:    newLinks,
 		Mention:     "@parkr",
 	})
 	if err != nil {
 		t.Fatalf("Failed: expected err to be nil, but was %#v", err)
 	}
 	if body != expected {
+		assert.Equal(t, expected, body)
 		t.Fatalf("Failed: expected\n\n%s\n\n, got:\n\n%s", expected, body)
 	}
 }

--- a/github_test.go
+++ b/github_test.go
@@ -12,15 +12,15 @@ func TestJoinLinksIntoBody(t *testing.T) {
 	newLinks := []RadarItem{{URL: "https://byparker.com"}, {URL: "https://jvns.ca"}}
 	expected := header + `
 
-## [*Previously:*](https://github.com/parkr/radar/issues/1)
-
-  * [ ] [GitHub: Where the world builds software · GitHub](https://github.com)
-  * [ ] [Ben Balter](https://ben.balter.com)
-
 ## New:
 
   * [ ] [Parker Moore | By Parker](https://byparker.com)
   * [ ] [Julia Evans](https://jvns.ca)
+
+## [*Previously:*](https://github.com/parkr/radar/issues/1)
+
+  * [ ] [GitHub: Where the world builds software · GitHub](https://github.com)
+  * [ ] [Ben Balter](https://ben.balter.com)
 `
 
 	body, err := generateBody(&tmplData{

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-github/v48 v48.0.0
 	github.com/google/uuid v1.3.0
 	github.com/mailgun/mailgun-go/v4 v4.8.1
+	github.com/parkr/changelog v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/technoweenie/grohl v0.0.0-20140924204239-f4613feb389e
 	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mailgun/mailgun-go/v4 v4.8.1
 	github.com/parkr/changelog v1.1.0
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.8.0
 	github.com/technoweenie/grohl v0.0.0-20140924204239-f4613feb389e
 	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect
 	golang.org/x/net v0.0.0-20221017152216-f25eb7ecb193 // indirect

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OH
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/parkr/changelog v1.1.0 h1:ln7CL1aN42HCPpX8x2c7E1cZ9sPCjec4fvSQDRQLEjw=
+github.com/parkr/changelog v1.1.0/go.mod h1:fLJa1VplB6TqAgyc8A6JuOgLiC/5emC7wT1XdSBcMXE=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -220,12 +222,15 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/technoweenie/grohl v0.0.0-20140924204239-f4613feb389e h1:C96my5kght8CqB7dsf3RuBGRwC+kE15Xqt6xTJGhv2Y=
 github.com/technoweenie/grohl v0.0.0-20140924204239-f4613feb389e/go.mod h1:DTwHbmk3crL4f3wYVW8kGhPwnwvO3B51wR+XR1yD2Ww=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -673,8 +678,9 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/parser_test.go
+++ b/parser_test.go
@@ -57,6 +57,15 @@ A new day! Here's what you have saved:
 	assert.Len(t, items, 30, "expecting 30 radar items")
 }
 
+func Test_extractLinkedTodosFromMarkdown_newLinkCommentBody(t *testing.T) {
+	body := "- [ ] [changelog package - github.com/parkr/changelog@v1.1.0](https://pkg.go.dev/github.com/parkr/changelog@v1.1.0)"
+
+	items, err := extractLinkedTodosFromMarkdown(body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []RadarItem{{Title: "changelog package - github.com/parkr/changelog@v1.1.0", URL: "https://pkg.go.dev/github.com/parkr/changelog@v1.1.0"}}, items)
+}
+
 func Test_extractLinkedTodosFromMarkdown_changelogFormat(t *testing.T) {
 	body := `
 A new day, @parkr! Here's what you have saved:

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,7 +4,119 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func Test_extractLinkedTodosFromMarkdown_oldStyleBody(t *testing.T) {
+	body := `
+A new day! Here's what you have saved:
+
+[*Previously:*](https://github.com/parkr/daily/issues/1886)
+
+- [ ] [Ankify: convert notes to Anki cards](https://ankify.krxiang.com/?utm_source=hackernewsletter&utm_medium=email&utm_term=show_hn)
+- [ ] [WHERE TO WATCH BROADWAY ONLINE: THE THEATER LOVER’S GUIDE TO STREAMING](https://broadwaydirect.com/where-to-watch-musicals-online-the-musical-lovers-guide-to-streaming/)
+- [ ] [Coding Relic](https://codingrelic.geekhold.com/?m=1)
+- [ ] [“What's Next? (Black & White)” graphic tee, pullover hoodie, tank, and pullover crewneck by The West Wing Weekly. | Cotton Bureau](https://cottonbureau.com/products/whats-next-black-white#/4751515/tee-men-standard-tee-vintage-black-tri-blend-s)
+- [ ] [“Parrot Style” graphic tee, pullover hoodie, onesie, tank, and pullover crewneck by deadpine. | Cotton Bureau](https://cottonbureau.com/products/parrot-style#/1941684/tee-men-standard-tee-white-100percent-cotton-s)
+- [ ] [The West Wing Weekly | Cotton Bureau](https://cottonbureau.com/stores/the-west-wing-weekly#/shop)
+- [ ] [Fools Crow - Wikipedia](https://en.m.wikipedia.org/wiki/Fools_Crow)
+- [ ] [A Little Life - Wikipedia](https://en.m.wikipedia.org/wiki/A_Little_Life)
+- [ ] [Archiving a website with wget](https://gist.github.com/mullnerz/9fff80593d6b442d5c1b)
+- [ ] [gildas-lormeau/SingleFile: Web Extension for Firefox/Chrome/MS Edge and CLI tool to save a faithful copy of an entire web page in a single HTML file](https://github.com/gildas-lormeau/SingleFile?utm_source=hackernewsletter&utm_medium=email&utm_term=fav#projects-using-singlefile)
+- [ ] [direnv/direnv: unclutter your .profile](https://github.com/direnv/direnv?utm_source=tldrnewsletter)
+- [ ] [onceupon/Bash-Oneliner: A collection of handy Bash One-Liners and terminal tricks for data processing and Linux system maintenance.](https://github.com/onceupon/Bash-Oneliner)
+- [ ] [onceupon/Bash-Oneliner: A collection of handy Bash One-Liners and terminal tricks for data processing and Linux system maintenance.](https://github.com/onceupon/Bash-Oneliner)
+- [ ] [dns.toys/main.go at master · knadh/dns.toys · GitHub](https://github.com/knadh/dns.toys/blob/master/cmd/dnstoys/main.go)
+- [ ] [graham-essays: 📚 Download the full collection of Paul Graham essays in EPUB, Kindle & Markdown for easy reading.](https://github.com/ofou/graham-essays)
+- [ ] [Humism Watches](https://humism.com/)
+- [ ] [Song Notes](https://jamesfunk.net/songs-notes)
+- [ ] [Read Hackernews on Kindle](https://ktool.io/hacker-news-to-kindle)
+- [ ] [Email | Learn Netdata](https://learn.netdata.cloud/docs/agent/health/notifications/email)
+- [ ] [Keynote: The Potential of Machine Learning for Hardware Design - Jeff Dean](https://m.youtube.com/watch?v=FraDFZ2t__A&t=269s&pp=2AGNApACAQ%3D%3D)
+- [ ] [My simple note-taking setup | Zettelkasten in Obsidian | Step-by-step guide - YouTube](https://m.youtube.com/watch?v=E6ySG7xYgjY)
+- [ ] [Why Retaining Walls Collapse - YouTube](https://m.youtube.com/watch?v=--DKkzWVh-E)
+- [ ] [Heat Pumps are Not Hard: Here's what it will take to start pumping - YouTube](https://m.youtube.com/watch?v=43XKfuptnik)
+- [ ] [Day-Date Day Wheels, Ethical Quandaries, Counterweights, And A Question You Shouldn't Ask - YouTube](https://m.youtube.com/watch?v=VAt8_ow91yI)
+- [x] [The Mechanical Apple Watch | Watchfinder & Co. - YouTube](https://m.youtube.com/watch?v=BiPYOZnLJYo)
+- [ ] [Sundar Pichai, CEO of Google and Alphabet - YouTube](https://m.youtube.com/watch?v=j9qGmO8Yy-Y)
+- [ ] [Adam Falkner reads "Kissing Your Shoulder Blade Is the Most Honest Thing I've Done This Week" - YouTube](https://m.youtube.com/watch?v=QjkHEWFoEkY)
+- [ ] [Little Shop of Horrors: Tiny Desk (Home) Concert - YouTube](https://m.youtube.com/watch?v=ymqKPz5kRXE)
+- [ ] [Life is too short for dated CLI tools (Twitter thread)](https://mobile.twitter.com/amilajack/status/1479328649820000256)
+- [ ] [Overcast auf Twitter: „Want to join the Overcast beta group? TestFlight: https://t.co/SQ97C8KmA0 Slack group for feedback, bug reports, and feature discussion: https://t.co/mC7rGQ43f1 Scammers sometimes charge for these links. Please don’t fall for it! Overcast’s beta is always free.“ / Twitter](https://mobile.twitter.com/OvercastFM/status/1514597131587313664)
+- [ ] ["Shelter In Place" 5lb Bag : Ritual Coffee Roasters](https://ritualcoffee.com/shop/coffee/shelter-in-place-5lb/)
+
+
+/cc @parkr
+`
+	items, err := extractLinkedTodosFromMarkdown(body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, RadarItem{Title: "Ankify: convert notes to Anki cards", URL: "https://ankify.krxiang.com/?utm_source=hackernewsletter&utm_medium=email&utm_term=show_hn"}, items[0])
+	assert.Equal(t, RadarItem{Title: `"Shelter In Place" 5lb Bag : Ritual Coffee Roasters`, URL: "https://ritualcoffee.com/shop/coffee/shelter-in-place-5lb/"}, items[len(items)-1])
+	assert.Len(t, items, 30, "expecting 30 radar items")
+}
+
+func Test_extractLinkedTodosFromMarkdown_changelogFormat(t *testing.T) {
+	body := `
+A new day, @parkr! Here's what you have saved:
+
+## [*Previously:*](https://github.com/parkr/radar/issues/1)
+
+  * [ ] [GitHub: Where the world builds software · GitHub](https://github.com)
+  * [ ] [Ben Balter](https://ben.balter.com)
+
+## New:
+
+  * [ ] [Parker Moore | By Parker](https://byparker.com)
+  * [ ] [Julia Evans](https://jvns.ca)
+`
+	expected := []RadarItem{
+		{Title: "GitHub: Where the world builds software · GitHub", URL: "https://github.com"},
+		{Title: "Ben Balter", URL: "https://ben.balter.com"},
+		{Title: "Parker Moore | By Parker", URL: "https://byparker.com"},
+		{Title: "Julia Evans", URL: "https://jvns.ca"},
+	}
+
+	items, err := extractLinkedTodosFromMarkdown(body)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, items)
+}
+
+func Test_parseMarkdownLink(t *testing.T) {
+	testcases := []struct {
+		input string
+		title string
+		url   string
+	}{
+		{
+			input: "[Ankify: convert notes to Anki cards](https://ankify.krxiang.com/?utm_source=hackernewsletter&utm_medium=email&utm_term=show_hn)",
+			title: "Ankify: convert notes to Anki cards",
+			url:   "https://ankify.krxiang.com/?utm_source=hackernewsletter&utm_medium=email&utm_term=show_hn",
+		},
+		{
+			input: `[“What's Next? (Black & White)” graphic tee, pullover hoodie, tank, and pullover crewneck by The West Wing Weekly. | Cotton Bureau](https://cottonbureau.com/products/whats-next-black-white#/4751515/tee-men-standard-tee-vintage-black-tri-blend-s)`,
+			title: `“What's Next? (Black & White)” graphic tee, pullover hoodie, tank, and pullover crewneck by The West Wing Weekly. | Cotton Bureau`,
+			url:   "https://cottonbureau.com/products/whats-next-black-white#/4751515/tee-men-standard-tee-vintage-black-tri-blend-s",
+		},
+		{
+			input: `[Little Shop of Horrors: Tiny Desk (Home) Concert - YouTube](https://m.youtube.com/watch?v=ymqKPz5kRXE)`,
+			title: "Little Shop of Horrors: Tiny Desk (Home) Concert - YouTube",
+			url:   "https://m.youtube.com/watch?v=ymqKPz5kRXE",
+		},
+		{
+			input: `[Life is too short for dated CLI tools (Twitter thread)](https://mobile.twitter.com/amilajack/status/1479328649820000256)`,
+			title: "Life is too short for dated CLI tools (Twitter thread)",
+			url:   "https://mobile.twitter.com/amilajack/status/1479328649820000256",
+		},
+	}
+	for _, testcase := range testcases {
+		actualTitle, actualURL := parseMarkdownLink(testcase.input)
+		assert.Equal(t, testcase.title, actualTitle, "Link: %q", testcase.input)
+		assert.Equal(t, testcase.url, actualURL, "Link: %q", testcase.input)
+	}
+}
 
 func Test_isBinaryResource(t *testing.T) {
 	testcases := []struct {

--- a/radar_item.go
+++ b/radar_item.go
@@ -85,12 +85,12 @@ func (rs RadarItemsService) GetGitHubIssue(ctx context.Context) (*github.Issue, 
 }
 
 // List returns a list of parsed radar items present on the list.
-func (rs RadarItemsService) List(ctx context.Context) ([]RadarItem, error) {
+func (rs RadarItemsService) List(ctx context.Context) ([]RadarItem, []RadarItem, error) {
 	issue, err := rs.GetGitHubIssue(ctx)
 	if err != nil {
-		return nil, errors.WithMessage(err, "error fetching open issue")
+		return nil, nil, errors.WithMessage(err, "error fetching open issue")
 	}
-	return extractGitHubLinks(ctx, rs.githubClient, rs.owner, rs.repoName, issue), nil
+	return extractGitHubLinks(ctx, rs.githubClient, rs.owner, rs.repoName, issue)
 }
 
 // Create adds a RadarItem to the GitHub issue.

--- a/radar_item.go
+++ b/radar_item.go
@@ -33,6 +33,10 @@ func (r *RadarItem) GetHostname() string {
 	return r.parsedURL.Hostname()
 }
 
+func (r *RadarItem) GetMarkdown() string {
+	return "[" + r.GetTitle() + "](" + r.URL + ")"
+}
+
 type RadarItems []RadarItem
 
 func (r RadarItems) Len() int {

--- a/reply_test.go
+++ b/reply_test.go
@@ -1,0 +1,26 @@
+package radar
+
+import (
+	"testing"
+
+	mailgun "github.com/mailgun/mailgun-go/v4"
+)
+
+func TestSendReply(t *testing.T) {
+	mgMockServer := mailgun.NewMockServer()
+	defer mgMockServer.Stop()
+	mg := mailgun.NewMailgun("example.com", "faketestapikey")
+	mg.SetAPIBase(mgMockServer.URL())
+	svc := NewMailgunService(mg, "fromtest@example.com")
+
+	err := svc.SendReply(createRequest{
+		fromEmail: "fromtest@example.com",
+		messageID: "123abc",
+		subject:   "My cool radar item",
+		url:       "http://example.com/?thebest=true",
+	}, "Well done, Bob! Got it.")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
I had this elaborate parsing and template generation that I realized was somewhat duplicative of parkr/changelog. So, let's use a changelog format with headers (versions) "Previously:" and "New:". It took a bit of finagling to get the previous issue body to parse properly but I think I have it in a good place now.